### PR TITLE
Fix github outputs syntax

### DIFF
--- a/.github/workflows/terraform-module-feature-branch.yml
+++ b/.github/workflows/terraform-module-feature-branch.yml
@@ -137,7 +137,7 @@ jobs:
             | sort \
             | uniq \
             | jq --raw-input --slurp 'split("\n")| map(select(. != ""))')
-          echo "name=matrix::$(echo $matrix)" >> $GITHUB_OUTPUT
+          echo "matrix=$(echo $matrix)" >> $GITHUB_OUTPUT
     outputs:
       tfdirs_matrix: ${{ steps.set-matrix.outputs.matrix }}
 


### PR DESCRIPTION
Current syntax is broken, I think it's neither the old way to set output nor the new - just a typo.

Change to new syntax per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples